### PR TITLE
Feature/responsiveness

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -60,7 +60,7 @@ body {
   justify-content: space-between;
   align-items: center;
   min-height: 100vh;
-  min-width: 100vw;
+  width: 100%;
   color: white;
   position: absolute;
   font-family: "Montserrat";

--- a/src/Header.vue
+++ b/src/Header.vue
@@ -1,6 +1,5 @@
 <template>
   <header class='header'>
-    <h1>VUENIVERSE</h1>
     <section class="logo">
      <router-link to='/home'><h1>VUENIVERSE</h1></router-link>
      <p>Expand your Vue.</p>
@@ -88,5 +87,33 @@ export default {
   }
   ::-webkit-calendar-picker-indicator {
     filter: invert(1);
+}
+
+@media screen and (max-width: 550px) {
+  p {
+    display: none;
+  }
+  h1 {
+    font-size: medium;
+  }
+}
+
+@media screen and (max-width: 400px) {
+  .header {
+    flex-direction: column;
+    height: 10%;
+    text-align: center;
+  }
+  section {
+    margin: 3%;
+    width: 100%;
+  }
+  h1 {
+    width: 100%;
+    margin: 0%;
+  }
+  .home-link {
+    margin: 3%;
+  }
 }
 </style>

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -53,4 +53,10 @@
     color: #49A8C6;
   }
 
+  @media screen and (max-width: 430px) {
+    h2 {
+      font-size: larger;
+    }
+  }
+
 </style>

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -55,7 +55,7 @@
 
   @media screen and (max-width: 430px) {
     h2 {
-      font-size: larger;
+      font-size: medium;
     }
   }
 

--- a/src/views/PicOfTheDay.vue
+++ b/src/views/PicOfTheDay.vue
@@ -79,7 +79,7 @@ export default {
   color: #56BBCD;
 }
 
-@media screen and (max-width: 800px) {
+@media screen and (max-width: 875px) {
   .potd-component {
     flex-direction: column;
   }
@@ -92,6 +92,23 @@ export default {
   .video {
     min-width: 480px;
     height: 255px;
+    max-height: none;
+  }
+}
+
+@media screen and (max-width: 510px) {
+  .potd-component {
+    flex-direction: column;
+  }
+  .photo {
+    max-height: 350px;
+  }
+  .information {
+    margin-top: 5%;
+  }
+  .video {
+    min-width: 320px;
+    height: 170px;
     max-height: none;
   }
 }

--- a/src/views/PicOfTheDay.vue
+++ b/src/views/PicOfTheDay.vue
@@ -65,16 +65,34 @@ export default {
   flex-direction: column;
   justify-content: center;
   text-align: center;
+  margin-right: 3%;
 }
 
 .potd-date,
 .potd-title,
 .potd-copyright {
-  margin: 0;
+  margin: 0.5%;
 }
 
 .potd-explanation {
-  margin-top: 0;
+  margin-top: 0.5%;
   color: #56BBCD;
+}
+
+@media screen and (max-width: 800px) {
+  .potd-component {
+    flex-direction: column;
+  }
+  .photo {
+    max-height: 350px;
+  }
+  .information {
+    margin-top: 5%;
+  }
+  .video {
+    min-width: 480px;
+    height: 255px;
+    max-height: none;
+  }
 }
 </style>


### PR DESCRIPTION
## *Purpose:*
*What does this merge do? Check all that apply.*
- [x] Adds a new feature
- [ ] Improves an existing feature
- [ ] Fixes a bug
- [ ] Cleans up (logs, tests, etc.)


## *Description: What does this PR do?*
This PR adds media queries to most components for responsive design. The media queries vary at which size they are triggered depending on the component and its contents.

## *Instructions for reviewer:*
*Where should the reviewer start?*

I would start with the POTD component as well as the Header component. Small changes were also made to App and About.

*Any background context you want to provide?*

The content starts to become crowded at around 320px, but that seems to be the smallest available screen size so I think that's fine.

The added Yesterday and NextDay components will still need to be incorporated into the media queries when necessary.

## *Issues:*

The only issue I'm seeing is the first breakpoint, now at 875px, seems to be a bit late when viewed on an iPad Pro, but it also seems to early on a desktop to set the breakpoint at 1025px which would help the iPad display.

